### PR TITLE
Update for latest Bazel and googletest

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Build
+      run: bazel build ...
+
+    - name: Test
+      run: bazel test ... --test_output=errors

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,5 +4,5 @@ new_git_repository(
     name = "googletest",
     build_file = "@//:gmock.BUILD",
     remote = "https://github.com/google/googletest",
-    tag = "release-1.8.0",
+    tag = "release-1.10.0",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,8 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+
 new_git_repository(
     name = "googletest",
-    build_file = "gmock.BUILD",
+    build_file = "@//:gmock.BUILD",
     remote = "https://github.com/google/googletest",
     tag = "release-1.8.0",
 )


### PR DESCRIPTION
Implement a couple of small changes so that the build works with the latest Bazel release.
Also take the opportunity to update to the latest stable release of googletest.